### PR TITLE
Bump frontend overrides for serialize-javascript and yaml

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14477,9 +14477,9 @@
       "license": "MIT"
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
-      "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=20.0.0"
@@ -17147,9 +17147,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "license": "ISC",
       "engines": {
         "node": ">= 6"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,10 +27,11 @@
   "overrides": {
     "nth-check": "^2.0.1",
     "postcss": "^8.4.31",
-    "serialize-javascript": "^7.0.4",
+    "serialize-javascript": "^7.0.5",
     "webpack-dev-server": "^4.15.2",
     "@tootallnate/once": "^3.0.1",
-    "underscore": "^1.13.8"
+    "underscore": "^1.13.8",
+    "yaml": "^1.10.3"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Summary
Addresses the remaining Dependabot advisories that weren't auto-PR'd (they were blocked by Dependabot's default 5-open-PR cap):

- `serialize-javascript` override `^7.0.4` → `^7.0.5` — [GHSA-qj8w-gfj5-8c6v](https://github.com/advisories/GHSA-qj8w-gfj5-8c6v) CPU exhaustion DoS
- `yaml` override added at `^1.10.3` — [GHSA-48c2-rrv3-qjmp](https://github.com/advisories/GHSA-48c2-rrv3-qjmp) stack overflow via deeply nested collections

Also clears 4 transitive bubble-ups of `serialize-javascript`: `css-minimizer-webpack-plugin`, `rollup-plugin-terser`, `workbox-build`, `workbox-webpack-plugin`.

## Before / After
| | Before | After |
|---|---|---|
| `npm audit` (moderate) | 9 | 3 |
| `npm audit` (high) | 0 | 0 |

## Remaining alerts
3 moderate alerts will remain after this merge, all in the `webpack-dev-server` chain (`webpack-dev-server`, `@pmmmwh/react-refresh-webpack-plugin`, `react-scripts`). These are dev-only (source-code leak via WebSocket hijack while `npm start` is running) and CRA 5 pins `webpack-dev-server` to v4, so upgrading would require ejecting or migrating off CRA. Accepted risk — to be dismissed in the Security tab.

## Test plan
- [x] `npm install` succeeds with the new overrides
- [x] `npm run build` compiles successfully
- [x] `npm audit` reports only the 3 accepted-risk `webpack-dev-server` alerts